### PR TITLE
Park index

### DIFF
--- a/app/controllers/parks_controller.rb
+++ b/app/controllers/parks_controller.rb
@@ -1,0 +1,5 @@
+class ParksController < ApplicationController
+  def index
+    @parks = Park.all
+  end
+end

--- a/app/models/park.rb
+++ b/app/models/park.rb
@@ -1,0 +1,3 @@
+class Park < ApplicationRecord
+  
+end

--- a/app/views/parks/index.html.erb
+++ b/app/views/parks/index.html.erb
@@ -1,0 +1,5 @@
+<h1>Park Index</h1>
+
+<% @parks.each do |park| %>
+<p><%= park.name %></p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
 
   get '/cities', to: 'cities#index'
   get '/cities/:id', to: 'cities#show'
+  get '/parks', to: 'parks#index'
 end

--- a/spec/features/cities/index_spec.rb
+++ b/spec/features/cities/index_spec.rb
@@ -9,57 +9,11 @@ RSpec.describe "cities index page", type: :feature do
         city_3 = City.create!(name: 'Fort Collins', population: 80, state_capital: false)
 
         visit '/cities'
-        # save_and_open_page
 
         expect(page).to have_content(city.name)
         expect(page).to have_content(city_2.name)
+        expect(page).to have_content(city_3.name)
       end
-    end
-    describe 'when I visit /cities/:id' do
-      it 'I see the name of the City with that id' do
-        city = City.create!(name: 'Denver', population: 1000, state_capital: true)
-        city_2 = City.create!(name: 'Colorado Springs', population: 100, state_capital: false)
-
-        visit "/cities/#{city.id}"
-        # save_and_open_page
-
-        expect(page).to have_content(city.name)
-        expect(page).to_not have_content(city_2.name)
-
-      end
-
-      it 'I see the parent with that id including the population' do
-        city = City.create!(name: 'Denver', population: 1000, state_capital: true)
-        city_2 = City.create!(name: 'Colorado Springs', population: 120, state_capital: false)
-
-        visit "/cities/#{city.id}"
-        # save_and_open_page
-
-        expect(page).to have_content(city.population)
-        expect(page).to_not have_content(city_2.population)
-
-      end
-      it 'I see the parent with that id including if it is the State Capital' do
-        city = City.create!(name: 'Denver', population: 1000, state_capital: true)
-        city_2 = City.create!(name: 'Colorado Springs', population: 100, state_capital: false)
-
-        visit "/cities/#{city.id}"
-        # save_and_open_page
-
-        expect(page).to have_content("State Capital? Yes")
-        expect(page).to_not have_content("State Capital? No")
-
-      end
-    end
-
-    describe 'when I visit /parks' do
-      
     end
   end
-  # xit 'I see each child in the system' do
-  #   city = City.create!(name: 'Colorado Springs', population: 100, state_capital: false)
-
-  #   park_1 = Park.create!(name: 'Nancy Lewis Park', acres: 8.9)
-  # end
-  # it "including the child's attributes"
 end

--- a/spec/features/cities/show_spec.rb
+++ b/spec/features/cities/show_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "cities index page", type: :feature do
+
+  describe "as a visitor" do
+
+    describe 'when I visit /cities/:id' do
+      it 'I see the name of the City with that id' do
+        city = City.create!(name: 'Denver', population: 1000, state_capital: true)
+        city_2 = City.create!(name: 'Colorado Springs', population: 100, state_capital: false)
+
+        visit "/cities/#{city.id}"
+
+        expect(page).to have_content(city.name)
+        expect(page).to_not have_content(city_2.name)
+
+      end
+
+      it 'I see the parent with that id including the population' do
+        city = City.create!(name: 'Denver', population: 1000, state_capital: true)
+        city_2 = City.create!(name: 'Colorado Springs', population: 120, state_capital: false)
+
+        visit "/cities/#{city.id}"
+
+        expect(page).to have_content(city.population)
+        expect(page).to_not have_content(city_2.population)
+
+      end
+      
+      it 'I see the parent with that id including if it is the State Capital' do
+        city = City.create!(name: 'Denver', population: 1000, state_capital: true)
+        city_2 = City.create!(name: 'Colorado Springs', population: 100, state_capital: false)
+
+        visit "/cities/#{city.id}"
+
+        expect(page).to have_content("State Capital? Yes")
+        expect(page).to_not have_content("State Capital? No")
+      end
+    end
+  end
+end

--- a/spec/features/park/index_spec.rb
+++ b/spec/features/park/index_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe "park index page", type: :feature do
+  describe "as a visitor" do
+
+    describe 'when I visit /parks' do
+
+      it 'I see each Park name in the system' do 
+        park_1 = Park.create!(name: 'Nancy Lewis Park', acres: 8.9, visitor_center: false, playground: true, opening_hour: 5, closing_hour: 10)
+        park_2 = Park.create!(name: 'America the Beautiful Park', acres: 16.9, visitor_center: false, playground: true, opening_hour: 5, closing_hour: 10)
+        park_3 = Park.create!(name: 'Garden of the Gods', acres: 1341.3, visitor_center: true, playground: false, opening_hour: 5, closing_hour: 9)
+
+        visit '/parks'
+        save_and_open_page
+
+        expect(page).to have_content(park_1.name)
+        expect(page).to have_content(park_2.name)
+        expect(page).to have_content(park_3.name)
+      end
+      
+    end
+  end
+  # xit 'I see each child in the system' do
+  #   city = City.create!(name: 'Colorado Springs', population: 100, state_capital: false)
+
+  #   park_1 = Park.create!(name: 'Nancy Lewis Park', acres: 8.9)
+  # end
+  # it "including the child's attributes"
+end


### PR DESCRIPTION
Adds a park index page that shows the name of all the parks in the database. This also splits the RSpec test files up according to features.