### PR TITLE
Sort citys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development, :test do
   gem 'capybara'
   gem 'launchy' #save_and_open_page
   gem 'simplecov'
+  gem 'orderly'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,9 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
+    orderly (0.1.1)
+      capybara (>= 1.1)
+      rspec (>= 2.14)
     pg (1.4.3)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -139,6 +142,10 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.5.0)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
     rspec-expectations (3.11.0)
@@ -209,6 +216,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)
+  orderly
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 3.11)

--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -1,6 +1,6 @@
 class CitiesController < ApplicationController 
   def index
-    @cities = City.all
+    @cities = City.all.order(created_at: :desc)
   end
 
   def show

--- a/app/controllers/city_parks_controller.rb
+++ b/app/controllers/city_parks_controller.rb
@@ -1,5 +1,5 @@
 class CityParksController < ApplicationController
   def index
-    @city = City.find(params[:id])
+    @city = City.find(params[:id]).sort
   end
 end

--- a/app/views/cities/index.html.erb
+++ b/app/views/cities/index.html.erb
@@ -1,5 +1,8 @@
 <h1>Cities Index</h1>
 
 <% @cities.each do |city| %>
-  <p><%= city.name %></p>
-<% end %>
+  <p>
+    <b><%= city.name %></b>
+    <%="(created: #{city.created_at.strftime("%m/%d/%Y")})" %>
+  </p>
+  <% end %>

--- a/spec/features/cities/index_spec.rb
+++ b/spec/features/cities/index_spec.rb
@@ -5,17 +5,30 @@ RSpec.describe "cities index page", type: :feature do
   describe "as a visitor" do
 
     describe 'when I visit /cities' do
-      it 'then I see the name of each parent record in the system' do
-        city = City.create!(name: 'Denver', population: 1000, state_capital: true)
-        city_2 = City.create!(name: 'Colorado Springs', population: 100, state_capital: false)
-        city_3 = City.create!(name: 'Fort Collins', population: 80, state_capital: false)
+      before :each do
+        @city_1 = City.create!(name: 'Denver', population: 1000, state_capital: true)
+        @city_2 = City.create!(name: 'Colorado Springs', population: 100, state_capital: false)
+        @city_3 = City.create!(name: 'Fort Collins', population: 80, state_capital: false)
+      end
 
+      it 'then I see the name of each parent record in the system' do
         visit '/cities'
 
-        expect(page).to have_content(city.name)
-        expect(page).to have_content(city_2.name)
-        expect(page).to have_content(city_3.name)
+        expect(page).to have_content(@city_1.name)
+        expect(page).to have_content(@city_2.name)
+        expect(page).to have_content(@city_3.name)
       end
+
+      it 'I see that records are ordered by most recently created first' do
+        visit '/cities'
+        
+        expect('Fort Collins').to appear_before('Denver')
+        expect('Fort Collins').to appear_before('Colorado Springs')
+        expect('Colorado Springs').to appear_before('Denver')
+
+      end
+
+      it 'I see when it was created next to the record'
     end
   end
 end

--- a/spec/features/cities/index_spec.rb
+++ b/spec/features/cities/index_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "cities index page", type: :feature do
 
     describe 'when I visit /cities' do
       before :each do
-        @city_1 = City.create!(name: 'Denver', population: 1000, state_capital: true)
-        @city_2 = City.create!(name: 'Colorado Springs', population: 100, state_capital: false)
-        @city_3 = City.create!(name: 'Fort Collins', population: 80, state_capital: false)
+        @city_1 = City.create!(name: 'Denver', population: 1000, state_capital: true, created_at: '2022-07-01')
+        @city_2 = City.create!(name: 'Colorado Springs', population: 100, state_capital: false, created_at: '2022-08-01')
+        @city_3 = City.create!(name: 'Fort Collins', population: 80, state_capital: false, created_at: '2022-08-22')
       end
 
       it 'then I see the name of each parent record in the system' do
@@ -21,6 +21,8 @@ RSpec.describe "cities index page", type: :feature do
 
       it 'I see that records are ordered by most recently created first' do
         visit '/cities'
+
+        save_and_open_page
         
         expect('Fort Collins').to appear_before('Denver')
         expect('Fort Collins').to appear_before('Colorado Springs')
@@ -28,7 +30,11 @@ RSpec.describe "cities index page", type: :feature do
 
       end
 
-      it 'I see when it was created next to the record'
+      it 'I see when it was created next to the record' do 
+        visit '/cities/'
+
+        expect(page).to have_content('Fort Collins (created: 08/22/2022')
+      end
     end
   end
 end

--- a/spec/features/city_parks/index_spec.rb
+++ b/spec/features/city_parks/index_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "city parks index page", type: :feature do
 
     describe 'when I visit /cities/:city_id/parks' do
       before :each do
-        
+
         @city_1 = City.create!(name: 'Colorado Springs', population: 100, state_capital: false)
 
         @park_1 = @city_1.parks.create!(name: 'Nancy Lewis Park', acres: 8.9, visitor_center: false, playground: true, opening_hour: 5, closing_hour: 10)


### PR DESCRIPTION
Define how cities are sorted on the index page to be the most recently added city first. Also added created at date next to each city name.