### PR TITLE
Add filter to park index to only show parks that do have a playground

### DIFF
--- a/app/controllers/parks_controller.rb
+++ b/app/controllers/parks_controller.rb
@@ -1,6 +1,6 @@
 class ParksController < ApplicationController
   def index
-    @parks = Park.all
+    @parks = Park.where(playground: true)
   end
 
   def show

--- a/app/views/parks/index.html.erb
+++ b/app/views/parks/index.html.erb
@@ -8,7 +8,19 @@
 <% @parks.each do |park| %>
   <h3><%= park.name %></h3>
   <p><b>Acres: </b><%= park.acres %></p>
-  <p><b>Has Visitor Center? </b><%= park.visitor_center %></p>
-  <p><b>Has Playground? </b><%= park.playground %></p>
+  <p><b>Has Visitor Center? </b>
+    <% if park.visitor_center == true %>
+      <%= 'Yes' %>
+    <% else %>
+      <%= 'No' %>
+    <% end %>
+  </p>
+  <p><b>Has Playground? </b>
+    <% if park.playground == true %>
+      <%= 'Yes' %>
+    <% else %>
+      <%= 'No' %>
+    <% end %>
+  </p>
   <p><b>Park Hours: </b><%= park.opening_hour %> AM - <%= park.closing_hour %> PM</p>
 <% end %>

--- a/spec/features/park/index_spec.rb
+++ b/spec/features/park/index_spec.rb
@@ -7,47 +7,43 @@ RSpec.describe 'park index page', type: :feature do
       before :each do
         @city_1 = City.create!(name: 'Colorado Springs', population: 100, state_capital: false)
 
-        @park_1 = @city_1.parks.create!(name: 'Nancy Lewis Park', acres: 8.9, visitor_center: false, playground: true, opening_hour: 5, closing_hour: 10)
-        @park_2 = @city_1.parks.create!(name: 'America the Beautiful Park', acres: 16.9, visitor_center: false, playground: true, opening_hour: 5, closing_hour: 10)
-        @park_3 = @city_1.parks.create!(name: 'Garden of the Gods', acres: 1341.3, visitor_center: true, playground: false, opening_hour: 5, closing_hour: 9)
+        @park_1 = @city_1.parks.create!(name: 'Nancy Lewis Park', acres: 9, visitor_center: false, playground: true, opening_hour: 5, closing_hour: 10)
+        @park_2 = @city_1.parks.create!(name: 'America the Beautiful Park', acres: 17, visitor_center: true, playground: true, opening_hour: 6, closing_hour: 9)
+        @park_3 = @city_1.parks.create!(name: 'Garden of the Gods', acres: 1341, visitor_center: true, playground: false, opening_hour: 5, closing_hour: 9)
       end
 
       it 'I see each Park name in the system' do 
         visit '/parks'
         save_and_open_page
 
-        expect(page).to have_content(@park_1.name)
-        expect(page).to have_content(@park_2.name)
-        expect(page).to have_content(@park_3.name)
+        expect(page).to have_content('Nancy Lewis Park')
+        expect(page).to have_content('America the Beautiful Park')
       end
 
       it 'I see the park with that id including the number of acres' do 
         visit '/parks'
 
-        expect(page).to have_content(@park_1.acres)
-        expect(page).to have_content(@park_2.acres)
-        expect(page).to have_content(@park_3.acres)
+        expect(page).to have_content("Acres: 9")
       end
 
       it 'I see the park with that id including if it has a visitor center' do
         visit '/parks'
 
-        expect(page).to have_content('Has Visitor Center? false')
-        expect(page).to have_content('Has Visitor Center? true')
+        expect(page).to have_content('Has Visitor Center? No')
+        expect(page).to have_content('Has Visitor Center? Yes')
       end
 
-      it 'I see the park with that id including if it has a visitor center' do
+      it 'I see the park with that id including if it has a playground' do
         visit '/parks'
 
-        expect(page).to have_content('Has Playground? true')
-        expect(page).to have_content('Has Playground? false')
+        expect(page).to have_content('Has Playground? Yes')
       end
 
       it 'I see the park with that id including its opening and closing hours' do
         visit '/parks'
 
         expect(page).to have_content('Park Hours: 5 AM - 10 PM')
-        expect(page).to have_content('Park Hours: 5 AM - 9 PM')
+        expect(page).to have_content('Park Hours: 6 AM - 9 PM')
       end
 
       it 'I see a link at the top of the page that takes me to the Park Index' do
@@ -64,6 +60,14 @@ RSpec.describe 'park index page', type: :feature do
         find_link('City Index').visible?
         click_link 'City Index'
         expect(page).to have_current_path(cities_path)
+      end
+
+      it 'I only see records where the playground column is `true`' do
+        visit '/parks'
+
+        expect(page).to have_content(@park_1.name)
+        expect(page).to have_content(@park_2.name)
+        expect(page).to_not have_content(@park_3.name)        
       end
     end
   end


### PR DESCRIPTION
Add a filter to the park index page to only show parks with a playground. Also had to fix how prior tests were tested due to this change. 